### PR TITLE
Updates actions versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: '15.x'
     - name: Cache Node.js modules

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: '15.x'
     - name: Cache Node.js modules
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         # npm cache files are stored in `~/.npm` on Linux/macOS
         path: ~/.npm
@@ -27,7 +27,8 @@ jobs:
     - name: Lint, test and build release SDK
       run: npm run ci
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: build
         path: build
+        overwrite: true


### PR DESCRIPTION
# Description

This PR updates the used version of few actions, especially:
- "cache", as the old versions will be [decommissioned](https://github.com/actions/cache/discussions/1510)
- "upload-artifact", [soon to be decomissioned too](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/)

Note: some actions are archived so I didn't touch them.